### PR TITLE
Adding buddybuild status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Buck Tracker
 
+[![BuddyBuild](https://dashboard.buddybuild.com/api/statusImage?appID=5657486f09d62f01003b8c15&branch=master&build=latest)](https://dashboard.buddybuild.com/apps/5657486f09d62f01003b8c15/build/latest)
+
 An iOS expense tracker app written in Swift
 
 Current version on App Store: v1.1.0


### PR DESCRIPTION
We really liked Buck Tracker and wanted to offer you a free continuous integration system [(buddybuild)](buddybuild.com) to make sure that your app always works!

If this sounds like something that may be helpful, setup is really simple and we've already taken most of the steps for you…[here](https://dashboard.buddybuild.com/apps/5657486f09d62f01003b8c15/build/latest) are the builds we've completed for Buck Tracker so far.

![screen shot 2015-11-26 at 10 40 37 am](https://cloud.githubusercontent.com/assets/13876667/11429267/649fefde-942a-11e5-906a-b0d7779df095.png)


To configure your builds and to to make sure we kick off a new build with every commit you make, simply login [here] (dashboard.buddybuild.com).

Finally, if you’d like to know the latest build status of your app directly from your repo page, we offer small status badges - like the one seen on the [flappyswift](https://github.com/fullstackio/FlappySwift) repo.

To help add these, we created this pull request by adding a couple of lines to the readme.

If you have any questions or would like to learn more about buddybuild, feel free to email team@buddybuild.com directly or use the Intercom button on the website.